### PR TITLE
Implement sets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export * as bigint from "./bigint";
 export * from "./strings";
 export * from "./object";
 export * as arrays from "./arrays";
+export * as sets from "./sets";
 export * from "./other";
 export * as coerce from "./coerce";

--- a/src/sets.ts
+++ b/src/sets.ts
@@ -1,0 +1,74 @@
+import { Fn } from "hotscript";
+import { Validator } from "./shared.types";
+
+interface SetType extends Fn {
+  return: Set<this["arg1"]["$outputType"]>;
+}
+
+export const set =  <
+    const Schema extends Validator<any, any>
+>(
+    chain: Schema
+) => ({
+    name: "set" as const,
+    $inputType: "root" as unknown as any,
+    $outputType: "set" as unknown as SetType,
+    parse: (arg: unknown) => {
+      if (typeof arg !== "object" || arg === null || !(arg instanceof Set)) throw new Error(`${arg} is not a set.`);
+      arg.forEach((el) => {
+        if (chain !== null) {
+          chain.parse(el);
+        } else {
+          throw new Error(
+            `No inner validator for set. Make sure to do c.set(c.someValidator())`
+          );
+        }
+      });
+      return arg;
+    },
+});
+
+interface Identity extends Fn {
+  return: this["arg0"];
+}
+
+export const nonEmpty = () => ({
+  name: "nonEmpty" as const,
+  $inputType: "set" as unknown as Set<any>,
+  $outputType: "set" as unknown as Identity,
+  parse: (arg: Set<any>) => {
+    if (arg.size === 0) throw new Error(`set is empty.`);
+    return arg;
+  },
+});
+
+export const min = (min: number) => ({
+  name: "min" as const,
+  $inputType: "set" as unknown as Set<any>,
+  $outputType: "set" as unknown as Identity,
+  parse: (arg: Set<any>) => {
+    if (arg.size < min) throw new Error(`Set is smaller than ${min}.`);
+    return arg;
+  },
+});
+
+export const max = (max: number) => ({
+  name: "max" as const,
+  $inputType: "set" as unknown as Set<any>,
+  $outputType: "set" as unknown as Identity,
+  parse: (arg: Set<any>) => {
+    if (arg.size > max) throw new Error(`Set is greater than ${max}.`);
+    return arg;
+  },
+});
+
+export const length = (length: number) => ({
+  name: "length" as const,
+  $inputType: "set" as unknown as Set<any>,
+  $outputType: "set" as unknown as Identity,
+  parse: (arg: Set<any>) => {
+    if (arg.size !== length)
+      throw new Error(`Set is not of length ${length}.`);
+    return arg;
+  },
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -20,6 +20,13 @@ import {
   length,
 } from "../src/arrays";
 import { literal } from "../src/literal";
+import {
+  set,
+  nonEmpty as setNonEmpty,
+  min as setMin,
+  max as setMax,
+  length as setLength,
+} from "../src/sets";
 
 describe("basic tests", () => {
   const c = initCorrettore([
@@ -36,6 +43,11 @@ describe("basic tests", () => {
     nullable,
     literal,
     optional,
+    set,
+    setNonEmpty,
+    setMin,
+    setMax,
+    setLength,
     coerce.coerce,
     coerce.stringCoerce,
     coerce.numberCoerce,
@@ -165,6 +177,38 @@ describe("basic tests", () => {
     const schema = c.string().array();
     type SchemaType = Infer<typeof schema>;
     type test = Expect<Equal<SchemaType, string[]>>;
+  });
+
+  test("sets", () => {
+    expect(() => c.set(c.string().min(2)).parse(new Set(["ab", "ba"]))).not.toThrow();
+    expect(() => c.set(c.string()).parse(new Set())).not.toThrow();
+    expect(() => c.set(c.string()).parse(new Set([42]))).toThrow();
+    expect(() =>
+        c.set(c.string()).nonEmpty().parse(new Set(["a", "b"]))
+    ).not.toThrow();
+    expect(() => c.set(c.string()).nonEmpty().parse(new Set([]))).toThrow();
+    expect(() =>
+        c
+            .set(c.string())
+            .nonEmpty()
+            .min(3)
+            .max(5)
+            .length(4)
+            .parse(new Set(["a", "b", "c", "d"]))
+    ).not.toThrow();
+    expect(() =>
+        c
+            .set(c.string())
+            .nonEmpty()
+            .min(3)
+            .max(5)
+            .length(4)
+            .parse(new Set(["a", "b", "d"]))
+    ).toThrow();
+
+    const schema = c.set(c.string());
+    type SchemaType = Infer<typeof schema>;
+    type test = Expect<Equal<SchemaType, Set<string>>>;
   });
 
   test("nullable", () => {


### PR DESCRIPTION
Closes #7 

The added test case is a modified copy of one for `.array`.


Note that Zod's `.array` offers `z.string().array()` as an alternate syntax for `z.array(z.string())`, but `.set` does not.
We may support such chaining utility later, but not now.