### PR TITLE
Add or operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "prettier:write": "prettier --write .",
     "check:lint": "eslint .",
     "check:format": "prettier --check .",
-    "check:types": "tsc --noEmit --pretty"
+    "check:types": "tsc --noEmit --pretty",
+    "check:all": "bun check:lint && bun check:format && bun check:types && bun test"
   },
   "keywords": [],
   "author": "Mieszko Sabo",

--- a/src/other.ts
+++ b/src/other.ts
@@ -78,3 +78,48 @@ export const optional = (innerValidator?: Validator<any, any>) => {
     },
   };
 };
+
+interface OrSchema extends Fn {
+  return: this["args"] extends [...any, infer prev, infer last]
+    ? last extends { $outputType: infer T1 }
+      ? prev extends { $outputType: infer T2 }
+        ? T1 | T2
+        : T1 | prev
+      : prev extends { $outputType: infer T2 }
+        ? last | T2
+        : last | prev
+    : never;
+}
+
+export const or = <T1, T2>(innerValidator: Validator<T1, any>) => {
+  const ctx = {
+    chain: null as Validator<T2, any> | null,
+  } satisfies { chain: Validator<T2, any> | null };
+
+  return {
+    name: "or" as const,
+    $inputType: "any" as unknown as T1 | T2,
+    $outputType: "any" as unknown as OrSchema,
+    processChain: (chain: Validator<T2, any> | null) => {
+      if (chain !== null) {
+        ctx.chain = chain;
+      }
+      return [];
+    },
+    parse: (arg: any) => {
+      if (arg === null) return arg;
+      const chain = ctx.chain;
+      if (chain === null) {
+        throw new Error(
+          `No inner validator. Make sure to do c.someValidator().or(c.otherValidator())`,
+        );
+      }
+
+      try {
+        return chain.parse(arg);
+      } catch (e) {
+        return innerValidator.parse(arg);
+      }
+    },
+  };
+};

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -9,6 +9,7 @@ import {
   object,
   nullable,
   optional,
+  or,
   coerce,
 } from "../src";
 import { Equal, Expect } from "./helpers.types";
@@ -43,6 +44,7 @@ describe("basic tests", () => {
     nullable,
     literal,
     optional,
+    or,
     set,
     setNonEmpty,
     setMin,
@@ -237,5 +239,44 @@ describe("basic tests", () => {
     type _test = Expect<Equal<SchemaType, string>>;
 
     // TODO: test other coerce functions
+  });
+
+  describe("or", () => {
+    test("basic", () => {
+      const schema = c.string().or(c.number());
+      expect(schema.parse("yay")).toEqual("yay");
+      expect(schema.parse(42)).toEqual(42);
+      expect(() => schema.parse({ x: 42 })).toThrow();
+
+      type SchemaType = Infer<typeof schema>;
+      type _test = Expect<Equal<SchemaType, string | number>>;
+    });
+
+    test("literal", () => {
+      const schema = c.literal("a").or(c.literal(42));
+      expect(schema.parse("a")).toEqual("a");
+      expect(schema.parse(42)).toEqual(42);
+      expect(() => schema.parse("aaa")).toThrow();
+
+      type SchemaType = Infer<typeof schema>;
+      type _test = Expect<Equal<SchemaType, "a" | 42>>;
+    });
+
+    test("object", () => {
+      const schema = c.object({ x: number() }).or(c.object({ y: string() }));
+      // FIXME: .or should be chainable multiple times
+      // .or(c.string());
+      expect(schema.parse({ x: 42 })).toEqual({ x: 42 });
+      expect(schema.parse({ y: "foo" })).toEqual({ y: "foo" });
+      // expect(schema.parse("foo")).toEqual("foo");
+      expect(() => schema.parse({ x: "bar" })).toThrow();
+      expect(() => schema.parse({ y: 42 })).toThrow();
+
+      // strip keys in other schema
+      expect(schema.parse({ x: 42, y: "foo" })).toEqual({ x: 42 });
+
+      type SchemaType = Infer<typeof schema>;
+      type _test = Expect<Equal<SchemaType, { x: number } | { y: string }>>;
+    });
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -11,6 +11,7 @@ import {
   optional,
   or,
   coerce,
+  boolean,
 } from "../src";
 import { Equal, Expect } from "./helpers.types";
 import {
@@ -34,6 +35,7 @@ describe("basic tests", () => {
     string,
     min,
     number,
+    boolean,
     email,
     object,
     array,
@@ -243,32 +245,33 @@ describe("basic tests", () => {
 
   describe("or", () => {
     test("basic", () => {
-      const schema = c.string().or(c.number());
+      const schema = c.string().or(c.number()).or(c.boolean());
       expect(schema.parse("yay")).toEqual("yay");
       expect(schema.parse(42)).toEqual(42);
       expect(() => schema.parse({ x: 42 })).toThrow();
 
       type SchemaType = Infer<typeof schema>;
-      type _test = Expect<Equal<SchemaType, string | number>>;
+      type _test = Expect<Equal<SchemaType, string | number | boolean>>;
     });
 
     test("literal", () => {
-      const schema = c.literal("a").or(c.literal(42));
+      const schema = c.literal("a").or(c.literal(42)).or(c.literal("b"));
       expect(schema.parse("a")).toEqual("a");
       expect(schema.parse(42)).toEqual(42);
       expect(() => schema.parse("aaa")).toThrow();
 
       type SchemaType = Infer<typeof schema>;
-      type _test = Expect<Equal<SchemaType, "a" | 42>>;
+      type _test = Expect<Equal<SchemaType, "a" | 42 | "b">>;
     });
 
     test("object", () => {
-      const schema = c.object({ x: number() }).or(c.object({ y: string() }));
-      // FIXME: .or should be chainable multiple times
-      // .or(c.string());
+      const schema = c
+        .object({ x: number() })
+        .or(c.object({ y: string() }))
+        .or(c.string());
       expect(schema.parse({ x: 42 })).toEqual({ x: 42 });
       expect(schema.parse({ y: "foo" })).toEqual({ y: "foo" });
-      // expect(schema.parse("foo")).toEqual("foo");
+      expect(schema.parse("foo")).toEqual("foo");
       expect(() => schema.parse({ x: "bar" })).toThrow();
       expect(() => schema.parse({ y: 42 })).toThrow();
 
@@ -276,7 +279,9 @@ describe("basic tests", () => {
       expect(schema.parse({ x: 42, y: "foo" })).toEqual({ x: 42 });
 
       type SchemaType = Infer<typeof schema>;
-      type _test = Expect<Equal<SchemaType, { x: number } | { y: string }>>;
+      type _test = Expect<
+        Equal<SchemaType, { x: number } | { y: string } | string>
+      >;
     });
   });
 });


### PR DESCRIPTION
Part of #2 

Limitation: Zod allows chaining `.or` multiple times, like `z.string().or(z.number()).or(z.boolean())`, but this PR limits only one-time.
I couldn't make it 🤷‍♂️ 
I hope TypeScript experts fix this.